### PR TITLE
Fix ImportError: cannot import name 'dedent' from 'matplotlib.cbook'

### DIFF
--- a/lib/legacycontour/__init__.py
+++ b/lib/legacycontour/__init__.py
@@ -6,7 +6,7 @@ import sys
 import warnings
 
 import matplotlib as mpl
-from matplotlib.cbook import dedent
+from inspect import cleandoc as dedent
 import six
 
 from legacycontour.contourset import LegacyContourSet


### PR DESCRIPTION
Fix ImportError: cannot import name 'dedent' from 'matplotlib.cbook'

ref #1 